### PR TITLE
Fix namespace generated for DatabaseSeed stub

### DIFF
--- a/src/Jlapp/SmartSeeder/SeedMakeCommand.php
+++ b/src/Jlapp/SmartSeeder/SeedMakeCommand.php
@@ -49,7 +49,7 @@ class SeedMakeCommand extends Command {
 
         $fs = File::get(__DIR__."/stubs/DatabaseSeeder.stub");
 
-        $namespace = rtrim($this->getAppNamespace(), "/");
+        $namespace = rtrim($this->getAppNamespace(), "\\");
         $stub = str_replace('{{model}}', "seed_{$created}_".$model.'Seeder', $fs);
         $stub = str_replace('{{namespace}}', " namespace $namespace;", $stub);
         File::put($path, $stub);


### PR DESCRIPTION
A seeder file generated for the stub still has backslash in the name
space like `namespace App\;` which is invalid. I made the rtrim() strip
the backslash instead which remove the last backslash. This fixed my
issue.