### PR TITLE
Change the default seedDir path

### DIFF
--- a/src/Jlapp/SmartSeeder/SeedMigrator.php
+++ b/src/Jlapp/SmartSeeder/SeedMigrator.php
@@ -136,13 +136,13 @@ class SeedMigrator extends Migrator {
      */
     public function resolve($file)
     {
-        $filePath = app_path()."/".config('smart-seeder.seedDir')."/".$file.".php";
+        $filePath = database_path()."/".config('smart-seeder.seedDir')."/".$file.".php";
         if (File::exists($filePath)) {
             require_once $filePath;
         } else if (!empty($this->repository->env)) {
-            require_once app_path()."/".config('smart-seeder.seedDir')."/".$this->repository->env."/".$file.".php";
+            require_once database_path()."/".config('smart-seeder.seedDir')."/".$this->repository->env."/".$file.".php";
         } else {
-            require_once app_path()."/".config('smart-seeder.seedDir')."/".App::environment()."/".$file.".php";
+            require_once database_path()."/".config('smart-seeder.seedDir')."/".App::environment()."/".$file.".php";
         }
 
         return new $file;

--- a/src/config/smart-seeder.php
+++ b/src/config/smart-seeder.php
@@ -5,5 +5,5 @@ return array(
      * DO NOT CHANGE THIS unless you also change the included migration, since this references the actual table in your database
      */
     'seedTable' => 'seeds',
-    'seedDir' => 'database/smartSeeds',
+    'seedDir' => 'smartSeeds',
 );


### PR DESCRIPTION
In Laravel 5, the database-related files have been moved to `/database`
from the base path rather than in `/app/database` folder.
Switch the seed migrator to look in the database file using
`database_path()` as the base and change the config file to just
`smartSeeds` instead.