### PR TITLE
Allow user to specify path to the new seeder

### DIFF
--- a/src/Jlapp/SmartSeeder/SeedMakeCommand.php
+++ b/src/Jlapp/SmartSeeder/SeedMakeCommand.php
@@ -34,7 +34,13 @@ class SeedMakeCommand extends Command {
     public function fire()
     {
         $model = ucfirst($this->argument('model'));
-        $path = base_path(config('smart-seeder.seedDir'));
+        $path = $this->option('path');
+        if (empty($path)) {
+            $path = base_path(config('smart-seeder.seedDir'));
+        }
+        else {
+            $path = base_path($path);
+        }
 
         $env = $this->option('env');
         if (!empty($env)) {
@@ -42,7 +48,8 @@ class SeedMakeCommand extends Command {
         }
 
         if (!File::exists($path)) {
-            File::makeDirectory($path);
+            // mode 0755 is based on the default mode Laravel use.
+            File::makeDirectory($path, 755, true);
         }
         $created = date('Y_m_d_His');
         $path .= "/seed_{$created}_{$model}Seeder.php";
@@ -83,6 +90,7 @@ class SeedMakeCommand extends Command {
     {
         return array(
             array('env', null, InputOption::VALUE_OPTIONAL, 'The environment to seed to.', null),
+            array('path', null, InputOption::VALUE_OPTIONAL, 'The relative path to the base path to generate the seed to.', null),
         );
     }
 }


### PR DESCRIPTION
Use can specify `php artisan seed:make --path={path from base_path()}` to have their seed file created in that location. In the process, it will also create any intermediary folder along the way.
